### PR TITLE
removed the cheapest price from the product detail response

### DIFF
--- a/src/Styla/Api/ProductDetailsTranslator.php
+++ b/src/Styla/Api/ProductDetailsTranslator.php
@@ -199,9 +199,9 @@ class ProductDetailsTranslator
             $price = $product->getCurrencyPrice($context->getCurrencyId());
 
             $oldPrice = null;
-            if ($product->getCheapestPrice()) {
+            /*if ($product->getCheapestPrice()) {
                 $oldPrice = $product->getCheapestPrice()->getCurrencyPrice($context->getCurrencyId());
-            }
+            }*/
 
             $list->add(
                 new ProductReferenceInfo(


### PR DESCRIPTION
This  bug happens when we trying to retrieve products with variants . It works for normal product without variants. However the issue is that the new version of shopware6  does not have "cheapest price" in its product entity.


Refer: https://github.com/shopware/shopware/blob/trunk/src/Core/Content/Product/ProductEntity.php
        